### PR TITLE
use hosted embedding model in embed.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean:
 
 .PHONY: test-parse
 test-parse:
-	python -m rag.parse --input private/RFQ_Commercial/NZT --output private/test/parsed --chunking_strategy "by_title"
+	python -m rag.parse --input private/RFQ_Commercial/NZT --output private/test/parsed --chunking_strategy "by_title" --folder_tags --combine_text_under_n_chars 50 --max_characters 750 --new_after_n_chars 500
 
 .PHONY: test-embed
 test-embed:
@@ -48,3 +48,10 @@ test:
 	$(MAKE) test-parse
 	$(MAKE) test-embed
 	$(MAKE) test-query
+
+.PHONY: test-hosted
+test-hosted:
+	$(MAKE) clean
+	$(MAKE) test-parse
+	$(MAKE) test-embed
+	$(MAKE) test-query-hosted

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test-query:
 
 .PHONY: test-query-hosted
 test-query-hosted:
-	python -m rag.query '${QUERY}' --path-to-db private/test/embedded --model-name meta-llama/Meta-Llama-3.1-70B-Instruct --top-k-retriever 5 --chat-model-endpoint {$HOSTED_CHAT} --embedding_model_path ${HOSTED_EMBED}
+	python -m rag.query '${QUERY}' --path-to-db private/test/embedded --model-name meta-llama/Meta-Llama-3.1-70B-Instruct --top-k-retriever 5 --chat-model-endpoint ${HOSTED_CHAT} --embedding_model_path ${HOSTED_EMBED}
 
 .PHONY: test
 test:
@@ -56,5 +56,5 @@ test:
 test-hosted:
 	$(MAKE) clean
 	$(MAKE) test-parse
-	$(MAKE) test-embed
+	$(MAKE) test-embed-hosted
 	$(MAKE) test-query-hosted

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 QUERY = "What is the name of the project? Please respond in JSON format."
+HOSTED_CHAT = "http://llama-31-70b-jordan.models.mlds-kserve.us.rdlabs.hpecorp.net/v1"
+HOSTED_EMBED = "http://embedding-tyler.models.mlds-kserve.us.rdlabs.hpecorp.net/v1"
 
 .PHONY: install
 install:
@@ -24,23 +26,24 @@ clean:
 
 .PHONY: test-parse
 test-parse:
-	python -m rag.parse --input private/RFQ_Commercial/NZT --output private/test/parsed --chunking_strategy "by_title" --folder_tags --combine_text_under_n_chars 50 --max_characters 750 --new_after_n_chars 500
+	python -m rag.parse --input private/RFQ_Commercial/NZT --output private/test/parsed --chunking_strategy "by_title" --folder_tags --combine_text_under_n_chars 50 --max_characters 1500 --new_after_n_chars 1500
 
 .PHONY: test-embed
 test-embed:
 	python -m rag.embed --data-path private/test/parsed --path-to-db private/test/embedded
 
+
+.PHONY: test-embed-hosted
+test-embed-hosted:
+	python -m rag.embed --data-path private/test/parsed --path-to-db private/test/embedded --embedding_model_path ${HOSTED_EMBED}
+
 .PHONY: test-query
 test-query:
-	# python -m rag.query "What is the name of the project?" --path-to-db private/test/embedded
-	# python -m rag.query "What is the name of the project?" --path-to-db private/test/embedded --model-name meta-llama/Llama-2-7b-chat-hf
 	python -m rag.query '${QUERY}' --path-to-db private/test/embedded --model-name meta-llama/Meta-Llama-3.1-8B-Instruct --top-k-retriever 5
 
 .PHONY: test-query-hosted
 test-query-hosted:
-	# python -m rag.query "What is the name of the project?" --path-to-db private/test/embedded
-	# python -m rag.query "What is the name of the project?" --path-to-db private/test/embedded --model-name meta-llama/Llama-2-7b-chat-hf
-	python -m rag.query '${QUERY}' --path-to-db private/test/embedded --model-name meta-llama/Meta-Llama-3.1-70B-Instruct --top-k-retriever 5 --chat-model-endpoint http://llama-31-70b-jordan.models.mlds-kserve.us.rdlabs.hpecorp.net/v1/ --embedding_model_path http://embedding-tyler.models.mlds-kserve.us.rdlabs.hpecorp.net/v1
+	python -m rag.query '${QUERY}' --path-to-db private/test/embedded --model-name meta-llama/Meta-Llama-3.1-70B-Instruct --top-k-retriever 5 --chat-model-endpoint {$HOSTED_CHAT} --embedding_model_path ${HOSTED_EMBED}
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ parse a test pdf in `RFQ_Commercial` and then `make test-embed` to embed the par
 vector db. Use `make test-query` to test querying a local LLM and `make test-query-hosted` to test
 the hosted endpoint path. Append `QUERY=<your new query here>` to change the test query.
 
+Run `make test` to run the entire `{parse,embed,query}` workflow from start to finish, and similar
+for `make test-embed` to run the version with hosted model endpoints.
+
 There are also multiple `requirements.txt`'s floating in various parts of the repo. The top-level
 `rag/requirements.txt` is the one I have in my `venv` while developing, built from installing parts
 of the other `requirements.txt` instances on top of each other.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ For ease of development, I am cannibalizing parts of the original code and putti
 
 I copied the `RFQ_Commercial` dir under `private/RFQ_Commercial` which is `.gitignore`-d. This is
 only referenced in the `Makefile` which has some convenience commands. E.g. run `make test-parse` to
-parse a test pdf in `RFQ_Commercial` and then `make test-embed` to embed the parsed results into a vector
-db. Use `make test-embed-hosted` to test the hosted endpoint path. Append `QUERY=<your new query
-here>` to change the test query.
+parse a test pdf in `RFQ_Commercial` and then `make test-embed` to embed the parsed results into a
+vector db. Use `make test-query` to test querying a local LLM and `make test-query-hosted` to test
+the hosted endpoint path. Append `QUERY=<your new query here>` to change the test query.
 
 There are also multiple `requirements.txt`'s floating in various parts of the repo. The top-level
 `rag/requirements.txt` is the one I have in my `venv` while developing, built from installing parts

--- a/rag/_defaults.py
+++ b/rag/_defaults.py
@@ -9,3 +9,5 @@ You are an assistant for answering questions.
 You are given the extracted parts of a long document and a question. Provide a conversational answer.
 If you don't know the answer, just say "I do not know." Don't make up an answer.
 """).strip("\n")
+# The embedding model hosted on houston errors out at larger batch sizes
+DEFAULT_MAX_EMBED_BSZ = 32


### PR DESCRIPTION
Adds the ability to use the hosted embedding endpoint in `rag/embed.py` (the endpoint was already used in `rag/query.py`. See `make test-hosted` for the full hosted-model (embedding and chat) workflow.