### PR TITLE
Add filtering, saving and multi-query options

### DIFF
--- a/rag/query.py
+++ b/rag/query.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 import chromadb
 import torch
+import pandas as pd
+import os
 from llama_index.core import VectorStoreIndex
 from llama_index.core.postprocessor import LLMRerank, SimilarityPostprocessor
 from llama_index.core.retrievers import VectorIndexRetriever
@@ -14,6 +16,8 @@ from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.llms.huggingface import HuggingFaceLLM
 from llama_index.llms.openllm import OpenLLM
 from llama_index.vector_stores.chroma import ChromaVectorStore
+from llama_index.core.vector_stores.types import (MetadataFilter,
+                                                  MetadataFilters)
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from rag._defaults import DEFAULT_HF_CHAT_MODEL, DEFAULT_HF_EMBED_MODEL, DEFAULT_SYTEM_PROMPT
@@ -27,9 +31,9 @@ def get_llama3_1_instruct_str(
 ) -> str:
     context_str = ""
     for node in nodes:
-        print(f"Context: {node.metadata}")
+        #print(f"Context: {node.metadata}")
         context_str += node.text.replace("\n", "  \n")
-    print(f"\nUsing {context_str=}\n")
+    #print(f"\nUsing {context_str=}\n")
 
     # https://huggingface.co/blog/not-lain/rag-chatbot-using-llama3
     context_and_query = f"""
@@ -130,11 +134,83 @@ def get_nodes(
         nodes = reranker.postprocess_nodes(nodes, query_bundle)
     return nodes
 
+def get_llm_answer(llm, tag, args, query_list=None):
+
+    filters=None
+    if tag:
+        filters = MetadataFilters(filters=[MetadataFilter(key="Tag", value=tag)], condition="or")
+    elif args.folder:
+        filters = MetadataFilters(filters=[MetadataFilter(key="Tag", value=args.folder)], condition="or")
+    
+    retriever = create_retriever(
+        cutoff=args.cutoff, top_k_retriever=args.top_k_retriever, filters=filters
+    )
+    
+    d = {}
+    d["Queries"] = []
+    d["Answers"] = []
+    d["Main Source"] = []
+    
+    if query_list:
+        d["Queries"] = query_list
+        
+        for q in query_list:
+            print("\nQuery: " + q)
+            nodes = get_nodes(q, retriever, reranker)
+            prefix = get_llama3_1_instruct_str(q, nodes, tokenizer)
+            
+            output_response = llm.complete(prefix)
+            print(f"{output_response.text=}\n")
+            
+            d["Answers"].append(output_response.text)
+            d["Main Source"].append(nodes[0].node.metadata["Source"] + ", page " + str(nodes[0].node.metadata["Page Number"]))
+    else:
+        d["Queries"] = [args.query]
+        
+        nodes = get_nodes(args.query, retriever, reranker)
+        prefix = get_llama3_1_instruct_str(args.query, nodes, tokenizer)
+        #print(f"\n{prefix=}\n")
+        output_response = llm.complete(prefix)
+        print(f"\n{output_response.text=}\n")
+        
+        d["Answers"].append(output_response.text)
+        d["Main Source"].append(nodes[0].node.metadata["Source"] + ", page " + str(nodes[0].node.metadata["Page Number"]))
+
+    if args.output_folder:
+        output_df = pd.DataFrame(data=d)
+        
+        suffix = "all_documents_mixed"
+        if tag:
+            suffix = tag
+        elif args.folder:
+            suffix = args.folder
+            
+        csv_name = args.output_folder + "/extracted_info_" + suffix +".csv"
+        print("Saving output to " + csv_name)
+        output_df.to_csv(csv_name, index=False)
+        
+
+def print_references(nodes):
+    # TODO: @garrett.goon - Delete below, just for debugging/visuals
+    print("\n **** REFERENCES **** \n")
+    for n in nodes[0:1]:
+        title = n.node.metadata["Source"]
+        page = n.node.metadata["Page Number"]
+        text = n.node.text
+        commit = n.node.metadata["Commit"]
+        doctag = n.node.metadata["Tag"]
+        newtext = text.encode("unicode_escape").decode("unicode_escape")
+        out_title = f"**Source:** {title}  \n **Page:** {page}  \n **Similarity Score:** {round((n.score * 100),3)}% \n"
+        out_text = f"**Text:**  \n {newtext}  \n"
+
+        print(f"\n{out_title=}")
+        print(f"{out_text=}\n")
+
 
 if __name__ == "__main__":
     print("\n**********  QUERYING **********\n")
     parser = argparse.ArgumentParser()
-    parser.add_argument("query", type=str, help="Query to ask of the llm")
+    parser.add_argument("--query", type=str, default="What is the meaning of life?", help="Query to ask of the llm")
     parser.add_argument("--path-to-db", type=str, default="db", help="path to chroma db")
     parser.add_argument(
         "--embedding_model_path",
@@ -199,6 +275,31 @@ if __name__ == "__main__":
         help="stream responses",
         action="store_true",
     )
+    parser.add_argument(
+        "--folder",
+        default=None,
+        type=str,
+        help="Only use documents initially under that folder name.",
+    )
+    parser.add_argument(
+        "--query-all",
+        help="Query documents from each folder separately. Overrides the --folder argument.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--query-file",
+        default=None,
+        type=str,
+        help="txt file containing a single query per line. Overrides the --query argument.",
+    )
+    parser.add_argument(
+        "--output-folder",
+        default=None,
+        type=str,
+        help="Save queries output to csv files under that path.",
+    )
+    
+    
     args = parser.parse_args()
     if "Meta-Llama-3.1" not in args.model_name:
         # Only tested with Meta-Llama-3.1 so far. The system prompt and tokenization would need to
@@ -208,18 +309,20 @@ if __name__ == "__main__":
     if args.top_k_reranker and args.top_k_reranker > args.top_k_retriever:
         raise ValueError("top_k_reranker, if provided, must be smaller than top_k_retriever.")
 
-    index, _ = load_data(args.embedding_model_path, args.path_to_db)
-    retriever = create_retriever(
-        cutoff=args.cutoff, top_k_retriever=args.top_k_retriever, filters=None
-    )
+    index, chunks = load_data(args.embedding_model_path, args.path_to_db)
+    
+    
+    tags = []
+    for i in range(len(chunks["ids"])):
+        eltags = chunks["metadatas"][i]["Tag"]
+        if eltags not in tags:
+            tags.append(eltags)
+    print("\nTags: " + str(tags) + "\n")
+    
+    
     reranker = LLMRerank(top_n=args.top_k_reranker) if args.top_k_reranker else None
-
-    nodes = get_nodes(args.query, retriever, reranker)
     tokenizer = AutoTokenizer.from_pretrained(args.model_name)
-
-    prefix = get_llama3_1_instruct_str(args.query, nodes, tokenizer)
-
-    print(f"\n{prefix=}\n")
+    
     generate_kwargs = {
         "do_sample": True,
         "temperature": args.temp,
@@ -239,20 +342,31 @@ if __name__ == "__main__":
         llm = get_local_llm(
             args.model_name, tokenizer, args.max_new_tokens, args.use_4bit_quant, generate_kwargs
         )
-    output_response = llm.complete(prefix)
-    print(f"\n{output_response.text=}\n")
+    
+    if args.output_folder and not os.path.exists(args.output_folder):
+        print(args.output_folder + " does not exist yet, creating it...")
+        os.makedirs(args.output_folder)
+    
+    
+    # Get the list of queries from the queries file
+    query_list = None
+    if args.query_file:
+        print("Using " + args.query_file + " as query list")
+        query_file = open(args.query_file, "r")
+        query_lines = query_file.readlines()
+        query_file.close()
+        
+        query_list = []
+        for query in query_lines:
+            query_list.append(query.replace("\n",""))
+    
+    # Loop though all folders if wanting to get query answers for all docs
+    if args.query_all:
+        for tag in tags:
+            print("\n\nApply query to " + tag + " folder only")
+            get_llm_answer(llm, tag, args, query_list)
+    
+    # Otherwise, get answers either from all documents mixed up, or from a single folder if using --folder parameter
+    else:
+        get_llm_answer(llm, None, args, query_list)
 
-    # TODO: @garrett.goon - Delete below, just for debugging/visuals
-    print("\n **** REFERENCES **** \n")
-    for n in nodes:
-        title = n.node.metadata["Source"]
-        page = n.node.metadata["Page Number"]
-        text = n.node.text
-        commit = n.node.metadata["Commit"]
-        doctag = n.node.metadata["Tag"]
-        newtext = text.encode("unicode_escape").decode("unicode_escape")
-        out_title = f"**Source:** {title}  \n **Page:** {page}  \n **Similarity Score:** {round((n.score * 100),3)}% \n"
-        out_text = f"**Text:**  \n {newtext}  \n"
-
-        print(f"\n{out_title=}")
-        print(f"{out_text=}\n")


### PR DESCRIPTION
Added multiple new parameters to query.py to get the ability to:

- Restrict the RAG response to only use documents from a specific folder (--folder option)
- Get RAG response for each document folder (--query-all option, overrides --folder if provided)
- Pass a list of queries from a txt file as parameter (--query-file option)
- Save the output (--output-folder option)